### PR TITLE
Add home/back toolbar and default page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>Browser</title>
+<style>
+  body { margin: 0; }
+  #toolbar { background: #eee; padding: 5px; display: flex; }
+  #toolbar button { margin-right: 10px; }
+  #webview { position: absolute; top: 40px; left: 0; right: 0; bottom: 0; }
+</style>
+</head>
+<body>
+  <div id="toolbar">
+    <button id="back">Назад</button>
+    <button id="home">Домой</button>
+  </div>
+  <webview id="webview" src="https://www.cryptopro.ru/sites/default/files/products/cades/demopage/cades_bes_sample.html"></webview>
+  <script>
+    const startURL = 'https://www.cryptopro.ru/sites/default/files/products/cades/demopage/cades_bes_sample.html';
+    const view = document.getElementById('webview');
+    document.getElementById('back').addEventListener('click', () => view.goBack());
+    document.getElementById('home').addEventListener('click', () => view.loadURL(startURL));
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "productName": "SingleSiteBrowser",
     "appId": "com.my_company.single_site_browser",
     "files": [
-      "dist/**/*"
+      "dist/**/*",
+      "index.html"
     ],
     "extraResources": [
       "embedded_ext_placeholder",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,15 @@ async function createWindow() {
     autoHideMenuBar: true,
     fullscreenable: false,
     webPreferences: {
-      preload: path.join(__dirname, 'preload.js')
+      preload: path.join(__dirname, 'preload.js'),
+      webviewTag: true
     }
   });
 
   win.setMenuBarVisibility(false);
   win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
-  await win.loadURL('https://example.com');
+  const indexPath = path.join(__dirname, '..', 'index.html');
+  await win.loadFile(indexPath);
 }
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
## Summary
- add a simple `index.html` with a toolbar
- enable `<webview>` support and load the new page
- include `index.html` in the build

## Testing
- `npm install`
- `npm run build-ts`


------
https://chatgpt.com/codex/tasks/task_e_686999c274488329afaa0f9b5a613add