### PR TITLE
Bundle extensions on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ The `dist` script disables publishing so no GitHub token is required. Resulting 
 
 ## Extension
 
-Place your packed extension inside `embedded_ext_placeholder/` before building. The directory will be packaged as-is.
+Two packed extensions are included in the repository (`iifchhfnnmpdbibifmljnfjhpififfog.zip` and `pfhgbfnnjiafkhfdkmpiflachepdcjod.zip`).
+During the build step they are automatically extracted into `embedded_ext_placeholder/` by the `prepare-ext` script so that they become part of the final executable.
+You can run this step manually via:
+
+```bash
+npm run prepare-ext
+```
+
+The resulting directories will then be packaged as-is.
 
 ## Native Messaging Host
 

--- a/embedded_ext_placeholder/README.md
+++ b/embedded_ext_placeholder/README.md
@@ -1,0 +1,3 @@
+This folder will be packaged with the application.
+Extensions are extracted here by the `npm run prepare-ext` script.
+You may place additional unpacked extensions inside subdirectories if needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "electron-tsc": "scripts/electron-tsc.js"
       },
       "devDependencies": {
+        "adm-zip": "^0.5.10",
         "electron": "^26.0.0",
         "electron-builder": "^24.6.0",
         "typescript": "^5.0.0"
@@ -659,6 +660,16 @@
       "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "scripts": {
     "start": "electron-tsc src/main.ts",
     "pack": "electron-builder --dir",
-    "dist": "npm run build-ts && electron-builder --publish never",
-    "build-ts": "tsc"
+    "dist": "npm run build-ts && npm run prepare-ext && electron-builder --publish never",
+    "build-ts": "tsc",
+    "prepare-ext": "node scripts/prepare-ext.js"
   },
   "devDependencies": {
     "electron": "^26.0.0",
     "electron-builder": "^24.6.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "adm-zip": "^0.5.10"
   },
   "build": {
     "productName": "SingleSiteBrowser",

--- a/scripts/prepare-ext.js
+++ b/scripts/prepare-ext.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const AdmZip = require('adm-zip');
+
+const v2Zip = path.join(__dirname, '..', 'iifchhfnnmpdbibifmljnfjhpififfog.zip');
+const v3Zip = path.join(__dirname, '..', 'pfhgbfnnjiafkhfdkmpiflachepdcjod.zip');
+const outDir = path.join(__dirname, '..', 'embedded_ext_placeholder');
+
+if (!fs.existsSync(outDir)) {
+  fs.mkdirSync(outDir, { recursive: true });
+} else {
+  for (const entry of fs.readdirSync(outDir)) {
+    if (entry === '.gitkeep' || entry === 'README.md') continue;
+    fs.rmSync(path.join(outDir, entry), { recursive: true, force: true });
+  }
+}
+
+function extract(zipPath, dirName) {
+  if (!fs.existsSync(zipPath)) {
+    console.error('Zip not found:', zipPath);
+    return;
+  }
+  const dest = path.join(outDir, dirName);
+  const zip = new AdmZip(zipPath);
+  zip.extractAllTo(dest, true);
+  console.log('Extracted', zipPath, 'to', dest);
+}
+
+extract(v2Zip, 'ext_v2');
+extract(v3Zip, 'ext_v3');
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,11 +32,23 @@ app.whenReady().then(async () => {
     console.warn('TODO: разместите manifest и бинарь хоста');
   }
 
-  const extPath = path.join(process.resourcesPath, 'embedded_ext_placeholder');
-  try {
-    await session.defaultSession.loadExtension(extPath, { allowFileAccess: true });
-    console.log('Extension loaded');
-  } catch (e) {
+  const extRoot = path.join(process.resourcesPath, 'embedded_ext_placeholder');
+  if (fs.existsSync(extRoot)) {
+    const dirs = fs.readdirSync(extRoot, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => path.join(extRoot, d.name));
+    for (const dir of dirs) {
+      try {
+        await session.defaultSession.loadExtension(dir, { allowFileAccess: true });
+        console.log('Extension loaded from', dir);
+      } catch (e) {
+        console.warn('Failed to load extension from', dir, e);
+      }
+    }
+    if (!dirs.length) {
+      console.warn('TODO: поместите сюда своё расширение');
+    }
+  } else {
     console.warn('TODO: поместите сюда своё расширение');
   }
 


### PR DESCRIPTION
## Summary
- add script to extract plugin extensions before packaging
- load all extracted extensions at runtime
- document usage of the new script
- keep placeholder folder for embedded extensions

## Testing
- `npm run build-ts`
- `npm run prepare-ext`


------
https://chatgpt.com/codex/tasks/task_e_68755d9d48b88329b722cc6042e0c490