### PR TITLE
Add CI artifact instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+embedded_ext_placeholder/ext_v2/
+embedded_ext_placeholder/ext_v3/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ npm run dist
 
 The `dist` script disables publishing so no GitHub token is required. Resulting installers or executables will be in the `dist/` folder.
 
+## GitHub Actions CI
+
+Continuous integration builds for Linux and Windows are configured in
+`.github/workflows/build.yml`. Each run installs dependencies, executes
+`npm run dist` and uploads the resulting binaries as artifacts.
+
+You can download the ready-made `.AppImage` or `.exe` from the **Actions** tab
+of your repository by selecting a build run and choosing the artifact for your
+platform.
+
 ## Extension
 
 Two packed extensions are included in the repository (`iifchhfnnmpdbibifmljnfjhpififfog.zip` and `pfhgbfnnjiafkhfdkmpiflachepdcjod.zip`).


### PR DESCRIPTION
## Summary
- document how GitHub Actions builds binaries and provides them as artifacts
- add `.gitignore`

## Testing
- `npm run build-ts`


------
https://chatgpt.com/codex/tasks/task_e_687561f41810832982a650dc113b4a97