### PR TITLE
Update window creation and extension loading

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, session, globalShortcut } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 
-async function createWindow() {
+function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
     kiosk: true,
     autoHideMenuBar: true,
@@ -16,7 +16,8 @@ async function createWindow() {
   win.setMenuBarVisibility(false);
   win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
   const indexPath = path.join(__dirname, '..', 'index.html');
-  await win.loadFile(indexPath);
+  win.loadFile(indexPath).catch(console.error);
+  return win;
 }
 
 async function loadExtensions() {
@@ -41,7 +42,7 @@ async function loadExtensions() {
   }
 }
 
-app.whenReady().then(async () => {
+app.whenReady().then(() => {
   ['CommandOrControl+T', 'CommandOrControl+N', 'F11', 'Alt+F4']
     .forEach(accel => globalShortcut.register(accel, () => {}));
 
@@ -54,10 +55,10 @@ app.whenReady().then(async () => {
     console.warn('TODO: разместите manifest и бинарь хоста');
   }
 
-  await createWindow();
+  createWindow();
 
   // Загрузка расширений после отображения окна
-  loadExtensions().catch(e => console.error(e));
+  setImmediate(() => loadExtensions().catch(console.error));
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
## Summary
- return `BrowserWindow` from `createWindow`
- load the index file without awaiting
- avoid awaiting `createWindow` during initialization
- load extensions on the next tick

## Testing
- `npm run dist`

------
https://chatgpt.com/codex/tasks/task_e_6875702eb4dc8329adc59f973583b55e