### PR TITLE
Implement Windows native host installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,4 @@ The resulting directories will then be packaged as-is.
 ## Native Messaging Host
 
 Provide your host manifest and executable inside `native_host_placeholder/` to package with the application.
-After the first run, copy the manifest and binary to:
-```
-{userData}/native_messaging/
-```
-where `{userData}` is reported by the app. If the directory is empty, you'll see a warning on startup.
+On Windows the app copies files from this folder to `{userData}/native_messaging/` automatically and registers the host in the registry. On Linux you still need to place the manifest and binary manually in `{userData}/native_messaging/` after the first run.

--- a/embedded_ext_placeholder/ping_ext/background.js
+++ b/embedded_ext_placeholder/ping_ext/background.js
@@ -1,0 +1,16 @@
+function tryConnect() {
+  let port;
+  try {
+    port = chrome.runtime.connectNative('com.example.echo');
+  } catch (e) {
+    console.error('connectNative failed', e);
+    setTimeout(tryConnect, 5000);
+    return;
+  }
+  port.postMessage({ text: 'hello' });
+  port.onMessage.addListener(msg => {
+    console.log('Received from native host', msg);
+  });
+}
+chrome.runtime.onStartup.addListener(tryConnect);
+chrome.runtime.onInstalled.addListener(tryConnect);

--- a/embedded_ext_placeholder/ping_ext/manifest.json
+++ b/embedded_ext_placeholder/ping_ext/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 3,
+  "name": "Ping Host Extension",
+  "version": "1.0",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "permissions": ["nativeMessaging"],
+  "action": {
+    "default_title": "Ping Host"
+  }
+}

--- a/native_host_placeholder/windows/echo-host.cmd
+++ b/native_host_placeholder/windows/echo-host.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0echo-host.js" %*

--- a/native_host_placeholder/windows/echo-host.js
+++ b/native_host_placeholder/windows/echo-host.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+process.stdin.on('readable', () => {
+  let lenBuf = process.stdin.read(4);
+  if (!lenBuf) return;
+  const len = lenBuf.readUInt32LE(0);
+  const dataBuf = process.stdin.read(len);
+  if (!dataBuf) return;
+  const msg = JSON.parse(dataBuf.toString('utf8'));
+  const resp = { text: 'echo:' + (msg.text || '') };
+  const respBuf = Buffer.from(JSON.stringify(resp), 'utf8');
+  const outLen = Buffer.alloc(4);
+  outLen.writeUInt32LE(respBuf.length, 0);
+  process.stdout.write(outLen);
+  process.stdout.write(respBuf);
+});

--- a/native_host_placeholder/windows/echo-host.json
+++ b/native_host_placeholder/windows/echo-host.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.example.echo",
+  "description": "Echo host",
+  "path": "__HOST_PATH__",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://__EXT_ID__/" ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, session, globalShortcut } from 'electron';
+import { execSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -19,16 +20,19 @@ async function createWindow() {
   await win.loadFile(indexPath);
 }
 
-async function loadExtensions() {
+interface LoadedExt { dir: string; id: string; }
+async function loadExtensions(): Promise<LoadedExt[]> {
   const extRoot = path.join(process.resourcesPath, 'embedded_ext_placeholder');
   if (fs.existsSync(extRoot)) {
     const dirs = fs.readdirSync(extRoot, { withFileTypes: true })
       .filter(d => d.isDirectory())
       .map(d => path.join(extRoot, d.name));
+    const loaded: LoadedExt[] = [];
     for (const dir of dirs) {
       try {
-        await session.defaultSession.loadExtension(dir, { allowFileAccess: true });
-        console.log('Extension loaded from', dir);
+        const ext = await session.defaultSession.loadExtension(dir, { allowFileAccess: true });
+        loaded.push({ dir, id: ext.id });
+        console.log('Extension loaded from', dir, 'id', ext.id);
       } catch (e) {
         console.warn('Failed to load extension from', dir, e);
       }
@@ -36,29 +40,57 @@ async function loadExtensions() {
     if (!dirs.length) {
       console.warn('TODO: поместите сюда своё расширение');
     }
+    return loaded;
   } else {
     console.warn('TODO: поместите сюда своё расширение');
   }
+  return [];
 }
 
 app.whenReady().then(async () => {
   ['CommandOrControl+T', 'CommandOrControl+N', 'F11', 'Alt+F4']
     .forEach(accel => globalShortcut.register(accel, () => {}));
 
+  const loadedExts = await loadExtensions();
+
   const nmDir = path.join(app.getPath('userData'), 'native_messaging');
   if (!fs.existsSync(nmDir)) {
     fs.mkdirSync(nmDir, { recursive: true });
   }
   const hasManifest = fs.readdirSync(nmDir).some(f => f.endsWith('.json'));
-  if (!hasManifest) {
+  if (!hasManifest && process.platform === 'win32') {
+    try {
+      const resDir = path.join(process.resourcesPath, 'native_host_placeholder', 'windows');
+      const hostScript = path.join(resDir, 'echo-host.js');
+      const hostCmd = path.join(resDir, 'echo-host.cmd');
+      const manifestTpl = path.join(resDir, 'echo-host.json');
+      if (fs.existsSync(hostScript) && fs.existsSync(manifestTpl) && fs.existsSync(hostCmd)) {
+        const exePath = path.join(nmDir, 'echo-host.cmd');
+        fs.copyFileSync(hostScript, path.join(nmDir, 'echo-host.js'));
+        fs.copyFileSync(hostCmd, exePath);
+        const pingExt = loadedExts.find(e => e.dir.endsWith('ping_ext'));
+        const extId = pingExt ? pingExt.id : '';
+        const manifestPath = path.join(nmDir, 'echo-host.json');
+        const manifestContent = fs.readFileSync(manifestTpl, 'utf8')
+          .replace('__HOST_PATH__', exePath.replace(/\\/g, '\\\\'))
+          .replace('__EXT_ID__', extId);
+        fs.writeFileSync(manifestPath, manifestContent, 'utf8');
+        try {
+          execSync(`reg add HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\com.example.echo /ve /t REG_SZ /d "${manifestPath}" /f`);
+        } catch (e) {
+          console.warn('Failed to register native messaging host', e);
+        }
+      } else {
+        console.warn('Native host resources not found');
+      }
+    } catch (e) {
+      console.warn('Failed to install native host', e);
+    }
+  } else if (!hasManifest) {
     console.warn('TODO: разместите manifest и бинарь хоста');
   }
 
   await createWindow();
-
-  // Загрузка расширений после отображения окна
-  loadExtensions().catch(e => console.error(e));
-
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();


### PR DESCRIPTION
## Summary
- add a simple ping extension that connects to a native host
- include echo native host script and manifest for Windows
- automatically install and register native host on Windows startup
- document Windows native host automation

## Testing
- `npm run build-ts`

------
https://chatgpt.com/codex/tasks/task_e_687575926ea88329abb64eecd6128566