### PR TITLE
Add logging via electron-log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "sfbrowser",
       "version": "1.0.0",
+      "dependencies": {
+        "electron-log": "^5.4.1"
+      },
       "bin": {
         "electron-tsc": "scripts/electron-tsc.js"
       },
@@ -1948,6 +1951,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.1.tgz",
+      "integrity": "sha512-QvisA18Z++8E3Th0zmhUelys9dEv7aIeXJlbFw3UrxCc8H9qSRW0j8/ooTef/EtHui8tVmbKSL+EIQzP9GoRLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "prepare-ext": "node scripts/prepare-ext.js"
   },
   "devDependencies": {
+    "adm-zip": "^0.5.10",
     "electron": "^26.0.0",
     "electron-builder": "^24.6.0",
-    "typescript": "^5.0.0",
-    "adm-zip": "^0.5.10"
+    "typescript": "^5.0.0"
   },
   "build": {
     "productName": "SingleSiteBrowser",
@@ -36,5 +36,8 @@
   },
   "bin": {
     "electron-tsc": "scripts/electron-tsc.js"
+  },
+  "dependencies": {
+    "electron-log": "^5.4.1"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
 import { app, BrowserWindow, session, globalShortcut } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
+import log from 'electron-log';
+
+log.transports.file.level = 'info';
+log.transports.file.maxSize = 5_242_880; // 5 MiB
+log.info('=== app start ===');
 
 async function createWindow() {
+  log.info('Creating browser window');
   const win = new BrowserWindow({
     kiosk: true,
     autoHideMenuBar: true,
@@ -16,28 +22,30 @@ async function createWindow() {
   win.setMenuBarVisibility(false);
   win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
   const indexPath = path.join(__dirname, '..', 'index.html');
+  log.info('Loading index from', indexPath);
   await win.loadFile(indexPath);
 }
 
 async function loadExtensions() {
   const extRoot = path.join(process.resourcesPath, 'embedded_ext_placeholder');
+  log.info('Looking for extensions in', extRoot);
   if (fs.existsSync(extRoot)) {
     const dirs = fs.readdirSync(extRoot, { withFileTypes: true })
       .filter(d => d.isDirectory())
       .map(d => path.join(extRoot, d.name));
-    for (const dir of dirs) {
-      try {
-        await session.defaultSession.loadExtension(dir, { allowFileAccess: true });
-        console.log('Extension loaded from', dir);
-      } catch (e) {
-        console.warn('Failed to load extension from', dir, e);
-      }
+      for (const dir of dirs) {
+        try {
+          await session.defaultSession.loadExtension(dir, { allowFileAccess: true });
+          log.info('Extension loaded from', dir);
+        } catch (e) {
+          log.warn('Failed to load extension from', dir, e);
+        }
     }
     if (!dirs.length) {
-      console.warn('TODO: поместите сюда своё расширение');
+      log.warn('TODO: поместите сюда своё расширение');
     }
   } else {
-    console.warn('TODO: поместите сюда своё расширение');
+    log.warn('TODO: поместите сюда своё расширение');
   }
 }
 
@@ -46,18 +54,21 @@ app.whenReady().then(async () => {
     .forEach(accel => globalShortcut.register(accel, () => {}));
 
   const nmDir = path.join(app.getPath('userData'), 'native_messaging');
+  log.info('Native messaging dir', nmDir);
   if (!fs.existsSync(nmDir)) {
     fs.mkdirSync(nmDir, { recursive: true });
   }
   const hasManifest = fs.readdirSync(nmDir).some(f => f.endsWith('.json'));
   if (!hasManifest) {
-    console.warn('TODO: разместите manifest и бинарь хоста');
+    log.warn('TODO: разместите manifest и бинарь хоста');
   }
 
+  log.info('Creating main window');
   await createWindow();
 
   // Загрузка расширений после отображения окна
-  loadExtensions().catch(e => console.error(e));
+  log.info('Loading extensions');
+  loadExtensions().catch(e => log.error(e));
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,1 +1,8 @@
-// Preload script
+import { contextBridge } from 'electron';
+import log from 'electron-log';
+
+contextBridge.exposeInMainWorld('log', {
+  info: (...args: any[]) => log.info(...args),
+  warn: (...args: any[]) => log.warn(...args),
+  error: (...args: any[]) => log.error(...args)
+});


### PR DESCRIPTION
## Summary
- use `electron-log` to record startup steps
- expose logging to renderer via preload script

## Testing
- `npm run build-ts`


------
https://chatgpt.com/codex/tasks/task_e_68764c10bed8832985c6429c41bde653