### PR TITLE
Enable verbose logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,9 @@ import * as path from 'path';
 import * as fs from 'fs';
 import log from 'electron-log';
 
-log.transports.file.level = 'info';
+const logLevel = (process.env.LOG_LEVEL || 'debug') as any;
+log.transports.file.level = logLevel;
+log.transports.console.level = logLevel;
 log.transports.file.maxSize = 5_242_880; // 5 MiB
 log.info('=== app start ===');
 


### PR DESCRIPTION
## Summary
- allow customizing log level via `LOG_LEVEL` env var
- default log level to `debug`

## Testing
- `npm install`
- `npm run build-ts`

------
https://chatgpt.com/codex/tasks/task_e_68765161d6b48329b9be5d47cdd58275