### PR TITLE
Update native messaging manifest path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,11 +68,20 @@ app.whenReady().then(async () => {
       try {
         fs.cpSync(placeholderDir, nmDir, { recursive: true });
         const stubPath = path.join(nmDir, 'cryptopro_stub.js');
+        const manifestPath = path.join(nmDir, 'ru.cryptopro.nmcades.json');
         if (fs.existsSync(stubPath)) {
           fs.chmodSync(stubPath, 0o755);
           log.info('Ensured execute permissions for native messaging stub', stubPath);
         } else {
           log.warn('Native messaging stub not found after copy', stubPath);
+        }
+        try {
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+          manifest.path = path.resolve(nmDir, 'cryptopro_stub.js');
+          fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+          log.info('Updated native messaging manifest', manifestPath, 'with path', manifest.path);
+        } catch (manifestErr) {
+          log.warn('Failed to update native messaging manifest:', manifestErr);
         }
         log.info('Native messaging placeholder copied to', nmDir);
       } catch (err) {


### PR DESCRIPTION
## Summary
- copy native messaging placeholder and update the CryptoPro manifest path after copying
- ensure the stub remains executable and log success when the manifest is rewritten
- warn if the manifest update fails so issues are visible in application logs

## Testing
- npm run build-ts

------
https://chatgpt.com/codex/tasks/task_e_68d9328ba490832990c183e093ff37e0