### PR TITLE
Handle native host placeholder from multiple locations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -62,9 +62,13 @@ app.whenReady().then(async () => {
   const hasManifest = nmContents.some(f => f.endsWith('.json'));
   const hasCryptoManifest = nmContents.includes('ru.cryptopro.nmcades.json');
   if (!hasManifest || !hasCryptoManifest) {
-    const placeholderDir = path.join(process.resourcesPath, 'native_host_placeholder');
-    log.info('Copying native messaging placeholder from', placeholderDir);
-    if (fs.existsSync(placeholderDir)) {
+    const placeholderCandidates = [
+      path.join(process.resourcesPath, 'native_host_placeholder'),
+      path.join(app.getAppPath(), 'native_host_placeholder')
+    ];
+    const placeholderDir = placeholderCandidates.find(candidate => fs.existsSync(candidate));
+    if (placeholderDir) {
+      log.info('Copying native messaging placeholder from', placeholderDir);
       try {
         fs.cpSync(placeholderDir, nmDir, { recursive: true });
         const stubPath = path.join(nmDir, 'cryptopro_stub.js');
@@ -88,7 +92,10 @@ app.whenReady().then(async () => {
         log.warn('Failed to copy native messaging placeholder:', err);
       }
     } else {
-      log.warn('Native host placeholder directory is missing', placeholderDir);
+      log.warn(
+        'Native host placeholder directory not found. Tried locations:',
+        placeholderCandidates.join(', ')
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- search both the resources directory and application path for the native host placeholder
- keep the existing copy-and-patch logic but log a warning when no placeholder is available

## Testing
- npm run build-ts
- npm run pack
- npm start *(fails: electron-tsc command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d935ae69d48329b8aaf4abbd107667