### PR TITLE
Add Windows launcher for CryptoPro native host stub

### DIFF
--- a/native_host_placeholder/cryptopro_stub.cmd
+++ b/native_host_placeholder/cryptopro_stub.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal enabledelayedexpansion
+set SCRIPT_DIR=%~dp0
+set NODE_STUB=
+
+rem Prefer Node.js located next to this script (portable deployments)
+if exist "%SCRIPT_DIR%node.exe" (
+  set "NODE_STUB=%SCRIPT_DIR%node.exe"
+) else (
+  for /f "usebackq delims=" %%I in (`where node 2^>nul`) do (
+    if not defined NODE_STUB set "NODE_STUB=%%I"
+  )
+)
+
+if not defined NODE_STUB (
+  echo Native host stub failed: Node.js runtime was not found.>&2
+  exit /b 1
+)
+
+"%NODE_STUB%" "%SCRIPT_DIR%cryptopro_stub.js"
+exit /b %errorlevel%

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,17 +71,24 @@ app.whenReady().then(async () => {
       log.info('Copying native messaging placeholder from', placeholderDir);
       try {
         fs.cpSync(placeholderDir, nmDir, { recursive: true });
-        const stubPath = path.join(nmDir, 'cryptopro_stub.js');
+        const stubFileName = process.platform === 'win32'
+          ? 'cryptopro_stub.cmd'
+          : 'cryptopro_stub.js';
+        const stubPath = path.join(nmDir, stubFileName);
+        const jsStubPath = path.join(nmDir, 'cryptopro_stub.js');
         const manifestPath = path.join(nmDir, 'ru.cryptopro.nmcades.json');
-        if (fs.existsSync(stubPath)) {
-          fs.chmodSync(stubPath, 0o755);
-          log.info('Ensured execute permissions for native messaging stub', stubPath);
-        } else {
+        if (process.platform !== 'win32' && fs.existsSync(jsStubPath)) {
+          fs.chmodSync(jsStubPath, 0o755);
+          log.info('Ensured execute permissions for native messaging stub', jsStubPath);
+        }
+        if (!fs.existsSync(stubPath)) {
           log.warn('Native messaging stub not found after copy', stubPath);
+        } else {
+          log.info('Native messaging stub ready', stubPath);
         }
         try {
           const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-          manifest.path = path.resolve(nmDir, 'cryptopro_stub.js');
+          manifest.path = path.resolve(nmDir, stubFileName);
           fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
           log.info('Updated native messaging manifest', manifestPath, 'with path', manifest.path);
         } catch (manifestErr) {


### PR DESCRIPTION
## Summary
- add a Windows-friendly launcher for the CryptoPro native messaging stub so Chrome can call Node
- resolve the native host manifest path to a platform-specific stub and keep execute permissions on POSIX systems

## Testing
- npm run build-ts

------
https://chatgpt.com/codex/tasks/task_e_68d9392bc994832995d1eb9852b4048b