### PR TITLE
Ensure CryptoPro stub built for Windows TypeScript builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "electron-tsc src/main.ts",
     "pack": "electron-builder --dir",
     "dist": "npm run build-cryptopro-stub && npm run build-ts && npm run prepare-ext && electron-builder --publish never",
+    "prebuild-ts": "npm run build-cryptopro-stub",
     "build-ts": "tsc",
     "prepare-ext": "node scripts/prepare-ext.js",
     "build-cryptopro-stub": "pkg native_host_placeholder/cryptopro_stub.js --target node18-win-x64 --output native_host_placeholder/cryptopro_stub.exe"

--- a/scripts/electron-tsc.js
+++ b/scripts/electron-tsc.js
@@ -3,6 +3,17 @@ const { spawnSync } = require('child_process');
 const path = require('path');
 
 const tsconfig = path.join(__dirname, '..', 'tsconfig.json');
+
+if (process.platform === 'win32') {
+  const buildStub = spawnSync('npm', ['run', 'build-cryptopro-stub'], {
+    stdio: 'inherit',
+  });
+
+  if (buildStub.status !== 0) {
+    process.exit(buildStub.status ?? 1);
+  }
+}
+
 const tsc = spawnSync('npx', ['tsc', '-p', tsconfig], { stdio: 'inherit' });
 if (tsc.status !== 0) {
   process.exit(tsc.status);


### PR DESCRIPTION
## Summary
- run the CryptoPro stub build step automatically before invoking the TypeScript compiler on Windows
- ensure the TypeScript build script automatically generates the CryptoPro stub via an npm pre-script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95fe03ee0832985658d1bd752ba16