### PR TITLE
Generate CryptoPro host binary during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 embedded_ext_placeholder/ext_v2/
 embedded_ext_placeholder/ext_v3/
 native_host_placeholder/cryptopro_stub.exe
+native_host_windows/nmcades.exe

--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ After the first run, copy the manifest and binary to:
 ```
 where `{userData}` is reported by the app. If the directory is empty, you'll see a warning on startup.
 
+### Windows build
+
+The repository ships with the official CryptoPro native messaging host inside
+`CAdES Browser Plug-in.zip`. The build pipeline extracts the signed
+`nmcades.exe` and its manifest into `native_host_windows/` via
+`npm run prepare-native-host` (executed automatically before TypeScript
+compilation, `npm run dist` and `npm start`). The generated executable is
+ignored by git, so only the sources required to build it are committed. During
+startup on Windows the application prefers this directory over the placeholder
+and rewrites the manifest so that the executable is referenced from the user's
+`native_messaging` folder without introducing any additional startup delay.
+
 ### CryptoPro stub
 
 A minimal CryptoPro native messaging stub is included for testing.

--- a/native_host_windows/ru.cryptopro.nmcades.json
+++ b/native_host_windows/ru.cryptopro.nmcades.json
@@ -1,0 +1,11 @@
+{
+  "name": "ru.cryptopro.nmcades",
+  "description": "Chrome and Opera Native Messaging Host for CAdES Browser plug-in",
+  "path": "nmcades.exe",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://iifchhfnnmpdbibifmljnfjhpififfog/",
+    "chrome-extension://epebfcehmdedogndhlcacafjaacknbcm/",
+    "chrome-extension://pfhgbfnnjiafkhfdkmpiflachepdcjod/"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "start": "electron-tsc src/main.ts",
     "pack": "electron-builder --dir",
-    "dist": "npm run build-cryptopro-stub && npm run build-ts && npm run prepare-ext && electron-builder --publish never",
-    "prebuild-ts": "npm run build-cryptopro-stub",
+    "dist": "npm run build-ts && npm run prepare-ext && electron-builder --publish never",
+    "prestart": "npm run prepare-native-host",
+    "prebuild-ts": "npm run prepare-native-host && npm run build-cryptopro-stub",
     "build-ts": "tsc",
     "prepare-ext": "node scripts/prepare-ext.js",
+    "prepare-native-host": "node scripts/prepare-native-host.js",
     "build-cryptopro-stub": "pkg native_host_placeholder/cryptopro_stub.js --target node18-win-x64 --output native_host_placeholder/cryptopro_stub.exe"
   },
   "devDependencies": {
@@ -27,7 +29,8 @@
     ],
     "extraResources": [
       "embedded_ext_placeholder",
-      "native_host_placeholder"
+      "native_host_placeholder",
+      "native_host_windows"
     ],
     "asar": true,
     "win": {

--- a/scripts/prepare-native-host.js
+++ b/scripts/prepare-native-host.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const AdmZip = require('adm-zip');
+
+const zipPath = path.join(__dirname, '..', 'CAdES Browser Plug-in.zip');
+const outDir = path.join(__dirname, '..', 'native_host_windows');
+
+if (!fs.existsSync(zipPath)) {
+  console.error('CryptoPro plug-in archive not found:', zipPath);
+  process.exit(1);
+}
+
+if (fs.existsSync(outDir)) {
+  for (const entry of fs.readdirSync(outDir)) {
+    fs.rmSync(path.join(outDir, entry), { recursive: true, force: true });
+  }
+} else {
+  fs.mkdirSync(outDir, { recursive: true });
+}
+
+const zip = new AdmZip(zipPath);
+
+function extractEntry(entryName, targetName) {
+  const entry = zip.getEntry(entryName);
+  if (!entry) {
+    console.error('Entry not found in archive:', entryName);
+    process.exit(1);
+  }
+  const data = entry.getData();
+  fs.writeFileSync(path.join(outDir, targetName ?? path.basename(entryName)), data);
+}
+
+extractEntry('CAdES Browser Plug-in/nmcades.exe');
+extractEntry('CAdES Browser Plug-in/nmcades.json', 'ru.cryptopro.nmcades.json');
+
+const manifestPath = path.join(outDir, 'ru.cryptopro.nmcades.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+
+const requiredOrigins = [
+  'chrome-extension://iifchhfnnmpdbibifmljnfjhpififfog/',
+  'chrome-extension://pfhgbfnnjiafkhfdkmpiflachepdcjod/'
+];
+manifest.allowed_origins = Array.from(new Set([...(manifest.allowed_origins || []), ...requiredOrigins]));
+manifest.path = 'nmcades.exe';
+
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+console.log('Prepared native host files in', outDir);


### PR DESCRIPTION
## Summary
- ignore the extracted CryptoPro native host binary so it is generated from the bundled archive during builds
- document that the signed executable is produced on demand rather than committed to the repository

## Testing
- npm run build-ts

------
https://chatgpt.com/codex/tasks/task_e_68d96490cab48329b2b2a2e5f82c2c7e