### PR TITLE
Add automated native host preparation for Linux and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 embedded_ext_placeholder/ext_v2/
 embedded_ext_placeholder/ext_v3/
 native_host_placeholder/cryptopro_stub.exe
-native_host_windows/nmcades.exe
+native_host_windows/
+native_host_linux/

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "electron": "^26.0.0",
         "electron-builder": "^24.6.0",
         "pkg": "^5.8.1",
+        "tar": "^6.2.0",
         "typescript": "^5.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "electron": "^26.0.0",
     "electron-builder": "^24.6.0",
     "pkg": "^5.8.1",
+    "tar": "^6.2.0",
     "typescript": "^5.0.0"
   },
   "build": {
@@ -30,6 +31,7 @@
     "extraResources": [
       "embedded_ext_placeholder",
       "native_host_placeholder",
+      "native_host_linux",
       "native_host_windows"
     ],
     "asar": true,

--- a/scripts/prepare-native-host.js
+++ b/scripts/prepare-native-host.js
@@ -1,48 +1,150 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { Readable } = require('stream');
+const { pipeline } = require('stream/promises');
+const zlib = require('zlib');
 const AdmZip = require('adm-zip');
+const tar = require('tar');
 
-const zipPath = path.join(__dirname, '..', 'CAdES Browser Plug-in.zip');
-const outDir = path.join(__dirname, '..', 'native_host_windows');
+const projectRoot = path.join(__dirname, '..');
 
-if (!fs.existsSync(zipPath)) {
-  console.error('CryptoPro plug-in archive not found:', zipPath);
-  process.exit(1);
-}
-
-if (fs.existsSync(outDir)) {
-  for (const entry of fs.readdirSync(outDir)) {
-    fs.rmSync(path.join(outDir, entry), { recursive: true, force: true });
+function cleanDirectory(dir) {
+  if (fs.existsSync(dir)) {
+    for (const entry of fs.readdirSync(dir)) {
+      fs.rmSync(path.join(dir, entry), { recursive: true, force: true });
+    }
+  } else {
+    fs.mkdirSync(dir, { recursive: true });
   }
-} else {
-  fs.mkdirSync(outDir, { recursive: true });
 }
 
-const zip = new AdmZip(zipPath);
+function ensureAllowedOrigins(manifest) {
+  const requiredOrigins = [
+    'chrome-extension://iifchhfnnmpdbibifmljnfjhpififfog/',
+    'chrome-extension://pfhgbfnnjiafkhfdkmpiflachepdcjod/'
+  ];
+  manifest.allowed_origins = Array.from(new Set([...(manifest.allowed_origins || []), ...requiredOrigins]));
+}
 
-function extractEntry(entryName, targetName) {
-  const entry = zip.getEntry(entryName);
-  if (!entry) {
-    console.error('Entry not found in archive:', entryName);
+function prepareWindowsHost() {
+  const zipPath = path.join(projectRoot, 'CAdES Browser Plug-in.zip');
+  const outDir = path.join(projectRoot, 'native_host_windows');
+
+  if (!fs.existsSync(zipPath)) {
+    console.error('CryptoPro plug-in archive not found:', zipPath);
     process.exit(1);
   }
-  const data = entry.getData();
-  fs.writeFileSync(path.join(outDir, targetName ?? path.basename(entryName)), data);
+
+  cleanDirectory(outDir);
+
+  const zip = new AdmZip(zipPath);
+
+  function extractEntry(entryName, targetName) {
+    const entry = zip.getEntry(entryName);
+    if (!entry) {
+      console.error('Entry not found in archive:', entryName);
+      process.exit(1);
+    }
+    const data = entry.getData();
+    fs.writeFileSync(path.join(outDir, targetName ?? path.basename(entryName)), data);
+  }
+
+  extractEntry('CAdES Browser Plug-in/nmcades.exe');
+  extractEntry('CAdES Browser Plug-in/nmcades.json', 'ru.cryptopro.nmcades.json');
+
+  const manifestPath = path.join(outDir, 'ru.cryptopro.nmcades.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  ensureAllowedOrigins(manifest);
+  manifest.path = 'nmcades.exe';
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log('Prepared native host files in', outDir);
 }
 
-extractEntry('CAdES Browser Plug-in/nmcades.exe');
-extractEntry('CAdES Browser Plug-in/nmcades.json', 'ru.cryptopro.nmcades.json');
+function readDebEntry(debBuffer, entryName) {
+  const MAGIC = '!<arch>\n';
+  if (debBuffer.length < MAGIC.length || debBuffer.slice(0, MAGIC.length).toString() !== MAGIC) {
+    throw new Error('Invalid deb archive');
+  }
+  let offset = MAGIC.length;
+  while (offset + 60 <= debBuffer.length) {
+    const header = debBuffer.slice(offset, offset + 60);
+    const rawName = header.slice(0, 16).toString().trim();
+    const name = rawName.endsWith('/') ? rawName.slice(0, -1) : rawName;
+    const size = parseInt(header.slice(48, 58).toString().trim(), 10);
+    const dataStart = offset + 60;
+    const dataEnd = dataStart + size;
+    if (name === entryName) {
+      return debBuffer.slice(dataStart, dataEnd);
+    }
+    offset = dataEnd + (size % 2 === 1 ? 1 : 0);
+  }
+  throw new Error(`Entry ${entryName} not found in deb archive`);
+}
 
-const manifestPath = path.join(outDir, 'ru.cryptopro.nmcades.json');
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+async function prepareLinuxHost() {
+  const debPath = path.join(projectRoot, 'cprocsp-pki-plugin-64_2.0.15500-1_amd64.deb');
+  const outDir = path.join(projectRoot, 'native_host_linux');
 
-const requiredOrigins = [
-  'chrome-extension://iifchhfnnmpdbibifmljnfjhpififfog/',
-  'chrome-extension://pfhgbfnnjiafkhfdkmpiflachepdcjod/'
-];
-manifest.allowed_origins = Array.from(new Set([...(manifest.allowed_origins || []), ...requiredOrigins]));
-manifest.path = 'nmcades.exe';
+  if (!fs.existsSync(debPath)) {
+    console.error('CryptoPro Linux plug-in package not found:', debPath);
+    process.exit(1);
+  }
 
-fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  cleanDirectory(outDir);
 
-console.log('Prepared native host files in', outDir);
+  const debBuffer = fs.readFileSync(debPath);
+  const dataTarGz = readDebEntry(debBuffer, 'data.tar.gz');
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nmcades-linux-'));
+
+  try {
+    await pipeline(
+      Readable.from(dataTarGz),
+      zlib.createGunzip(),
+      tar.x({ cwd: tempDir })
+    );
+
+    const binSource = path.join(tempDir, 'opt', 'cprocsp', 'bin', 'amd64');
+    const libSource = path.join(tempDir, 'opt', 'cprocsp', 'lib', 'amd64');
+    const manifestSource = path.join(tempDir, 'etc', 'opt', 'chrome', 'native-messaging-hosts', 'ru.cryptopro.nmcades.json');
+
+    if (!fs.existsSync(binSource) || !fs.existsSync(manifestSource)) {
+      throw new Error('Unexpected package layout in Linux plug-in');
+    }
+
+    fs.cpSync(binSource, path.join(outDir, 'opt', 'cprocsp', 'bin', 'amd64'), { recursive: true });
+    if (fs.existsSync(libSource)) {
+      fs.cpSync(libSource, path.join(outDir, 'opt', 'cprocsp', 'lib', 'amd64'), { recursive: true });
+    }
+
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.copyFileSync(manifestSource, path.join(outDir, 'ru.cryptopro.nmcades.json'));
+
+    const manifestPath = path.join(outDir, 'ru.cryptopro.nmcades.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    ensureAllowedOrigins(manifest);
+    manifest.path = path.join('opt', 'cprocsp', 'bin', 'amd64', 'nmcades');
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const nmcadesPath = path.join(outDir, manifest.path);
+    if (fs.existsSync(nmcadesPath)) {
+      fs.chmodSync(nmcadesPath, 0o755);
+    }
+
+    console.log('Prepared Linux native host files in', outDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  prepareWindowsHost();
+  await prepareLinuxHost();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,8 @@ function findNativeHostCandidates(): string[] {
   const order: string[] = [];
   if (process.platform === 'win32') {
     order.push('native_host_windows');
+  } else if (process.platform === 'linux') {
+    order.push('native_host_linux');
   }
   order.push('native_host_placeholder');
 
@@ -71,6 +73,19 @@ function findNativeHostCandidates(): string[] {
 }
 
 function findNativeHostExecutable(nmDir: string, manifestPathValue?: string): string | undefined {
+  const normalizedNmDir = path.resolve(nmDir);
+
+  if (manifestPathValue) {
+    const manifestCandidatePath = path.resolve(nmDir, manifestPathValue);
+    const isWithinDir = manifestCandidatePath === normalizedNmDir || manifestCandidatePath.startsWith(`${normalizedNmDir}${path.sep}`);
+    if (isWithinDir && fs.existsSync(manifestCandidatePath)) {
+      const relative = path.relative(nmDir, manifestCandidatePath);
+      if (!relative.startsWith('..')) {
+        return relative || path.basename(manifestCandidatePath);
+      }
+    }
+  }
+
   const entries = fs.readdirSync(nmDir);
   const lowerEntries = entries.map(entry => entry.toLowerCase());
   const manifestCandidate = manifestPathValue ? path.basename(manifestPathValue) : undefined;


### PR DESCRIPTION
## Summary
- unpack the Windows CryptoPro plug-in during the build and keep manifests updated
- extract the Linux CryptoPro native messaging host from the DEB package and bundle it with the app
- update the Electron app to locate Linux native host assets and ignore generated host directories in git

## Testing
- npm run build-ts

------
https://chatgpt.com/codex/tasks/task_e_68d9703578e08329a27632db1c10f487