### PR TITLE
Cache Electron artifacts in Windows build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,22 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.electron-builder-cache
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/.electron-cache
+            ${{ github.workspace }}/.electron-builder-cache
+          key: ${{ runner.os }}-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-
       - run: npm install
       - run: npm run dist
       - name: Upload Windows Artifact


### PR DESCRIPTION
## Summary
- configure build-windows job to store Electron caches inside the workspace
- add a GitHub Actions cache step for the Electron caches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97843850c8329af68c9f19c430572