### PR TITLE
Use NativeMessagingHosts directory for native host setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The resulting directories will then be packaged as-is.
 Provide your host manifest and executable inside `native_host_placeholder/` to package with the application.
 After the first run, copy the manifest and binary to:
 ```
-{userData}/native_messaging/
+{userData}/NativeMessagingHosts/
 ```
 where `{userData}` is reported by the app. If the directory is empty, you'll see a warning on startup.
 
@@ -57,7 +57,7 @@ compilation, `npm run dist` and `npm start`). The generated executable is
 ignored by git, so only the sources required to build it are committed. During
 startup on Windows the application prefers this directory over the placeholder
 and rewrites the manifest so that the executable is referenced from the user's
-`native_messaging` folder without introducing any additional startup delay.
+`NativeMessagingHosts` folder without introducing any additional startup delay.
 
 ### CryptoPro stub
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,8 +117,9 @@ app.whenReady().then(async () => {
   ['CommandOrControl+T', 'CommandOrControl+N', 'F11', 'Alt+F4']
     .forEach(accel => globalShortcut.register(accel, () => {}));
 
-  const nmDir = path.join(app.getPath('userData'), 'native_messaging');
-  log.info('Native messaging dir', nmDir);
+  const nmDirName = 'NativeMessagingHosts';
+  const nmDir = path.join(app.getPath('userData'), nmDirName);
+  log.info('Native messaging hosts dir', nmDir);
   if (!fs.existsSync(nmDir)) {
     fs.mkdirSync(nmDir, { recursive: true });
   }


### PR DESCRIPTION
## Summary
- update the main process to create and use the NativeMessagingHosts directory for native messaging hosts
- refresh the README instructions to point to the new NativeMessagingHosts location

## Testing
- npm run dist

------
https://chatgpt.com/codex/tasks/task_e_68d97c5a6330832986c3fa6d60223299