### PR TITLE
Guard plugin extraction against unsafe paths

### DIFF
--- a/scripts/prepare-native-host.js
+++ b/scripts/prepare-native-host.js
@@ -27,6 +27,22 @@ function ensureAllowedOrigins(manifest) {
   manifest.allowed_origins = Array.from(new Set([...(manifest.allowed_origins || []), ...requiredOrigins]));
 }
 
+function sanitizeRelativePath(entryPath) {
+  const unixPath = entryPath.replace(/\\/g, '/');
+
+  if (!unixPath || unixPath.startsWith('/') || /^[A-Za-z]:/.test(unixPath)) {
+    return null;
+  }
+
+  const normalized = path.posix.normalize(unixPath);
+
+  if (normalized === '..' || normalized.startsWith('../') || path.posix.isAbsolute(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
 function prepareWindowsHost() {
   const zipPath = path.join(projectRoot, 'CAdES Browser Plug-in.zip');
   const outDir = path.join(projectRoot, 'native_host_windows');
@@ -54,7 +70,13 @@ function prepareWindowsHost() {
       continue;
     }
 
-    const targetPath = path.join(outDir, relativePath);
+    const safeRelativePath = sanitizeRelativePath(relativePath);
+    if (!safeRelativePath) {
+      console.error('Unsafe path detected in plugin archive entry:', relativePath);
+      process.exit(1);
+    }
+
+    const targetPath = path.join(outDir, safeRelativePath);
 
     if (entry.isDirectory) {
       fs.mkdirSync(targetPath, { recursive: true });


### PR DESCRIPTION
## Summary
- copy every file from the CryptoPro plugin archive into the Windows native host bundle
- ensure the generated ru.cryptopro.nmcades.json still points to the bundled nmcades.exe and keeps required origins
- guard the native host extraction against unsafe archive paths that could escape the output directory

## Testing
- npm run prepare-native-host

------
https://chatgpt.com/codex/tasks/task_e_68efe0f9f8d8832983983cad1df5bf16